### PR TITLE
sys to util

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,7 +4,7 @@ var os = require('os')
     , nyam = require('./nyam')
     , exec = require('child_process').exec
     , opt = require('optimist').argv
-    , sys = require('sys')
+    , util = require('util')
     , utils = require('./utils')
     , ConfigObj = require('./config')
     , config = new ConfigObj()
@@ -17,12 +17,12 @@ var os = require('os')
  * @api private
  */
 run_nyam = function() {
-    
+
     //collect string passed in
     //with parameter
-    
+
     data = opt._;
-    
+
     if (opt._.length === 0) {
         opt._ = null;
     }
@@ -34,49 +34,49 @@ run_nyam = function() {
     opt.version = opt.version || opt.v;
     opt.find = opt.find || opt.f;
 
-    utils.file_exists(opt.verbose, config.path, function(success,json,err){	
+    utils.file_exists(opt.verbose, config.path, function(success,json,err){
       if(opt.verbose) utils.display_json('Config',json);
       if(!success && !opt.setup?true:false) {
           console.log("\nrun ".green.bold + "nyam -s".bold +" to setup your yammer client config!\n".green.bold);
       }else{
-        
+
         // --help
-        
+
         if (opt.help) {
           console.log(nyam.help);
-        
+
         // --version
-        
+
         } else if (opt.version){
-          console.log("0.0.7"); //temporary, I'm moving cli.js to the root at some point. 
-        
+          console.log("0.0.7"); //temporary, I'm moving cli.js to the root at some point.
+
         // --list / latest
-        
-        } else if (opt.list){	
+
+        } else if (opt.list){
           nyam.get_latest((opt.debug)?true:false, function(err, success){
             if(!success) utils.need_setup(err);
           });
 
         // --search
 
-        } else if (opt.find){	
+        } else if (opt.find){
           utils.isnull(opt.find,"missing search keyword, try again",function(isnull){
             if(!isnull) {
               nyam.search(opt.verbose, opt.find,10, function(err, success){
                 if(!success) utils.need_setup(err);
-              });  
-            }            
+              });
+            }
           })
-  
+
         // --setup
-        
+
         } else if (opt.setup){
           nyam.setup((opt.debug)?true:false, function(response){
               console.log(response);
-          })	
-            
+          })
+
         // --message
-            
+
         } else {
           if (data!="" || opt.message) {
               message = data[0] || opt.message;

--- a/lib/nyam.js
+++ b/lib/nyam.js
@@ -7,14 +7,14 @@ var fs = require('fs')
     , path = require('path')
     , querystring = require('querystring')
     , url = require('url')
-    , sys= require('sys')
+    , util = require('util')
     , OAuth = require('oauth').OAuth
     , ConfigObj = require('./config')
     , config = new ConfigObj()
     , utils = require('./utils')
     , nyam = require('./nyam')
     , colors = require('colors');
- 
+
 /**
  * Class variables.
  */
@@ -75,7 +75,7 @@ input = function(message, callback){
                 data += c;
                 break
         }
-    })	
+    })
 }
 /**
  * Setup yammer
@@ -91,13 +91,13 @@ exports.setup = function(verbose, callback){
             } else {
                 if (verbose) console.log('oauth_token :' + oauth_token);
                 if (verbose) console.log('oauth_token_secret :' + oauth_token_secret);
-                if (verbose) console.log('requestoken results :' + sys.inspect(results));
+                if (verbose) console.log('requestoken results :' + util.inspect(results));
                 console.log('\n:::::: we need to give this CLI tool access to yammer :::::::\n'.green.bold);
                 console.log('\nNavigate to: '.green + 'https://www.yammer.com/oauth/authorize?oauth_token='.grey.bold+ oauth_token.grey.bold+'\n');
                 return input("Enter authorization code: ".green, function(oauth_verifier){
                     oa.getOAuthAccessToken(
-                    oauth_token, 
-                    oauth_token_secret, 
+                    oauth_token,
+                    oauth_token_secret,
                     oauth_verifier,
                     function(error, oauth_access_token, oauth_access_token_secret, results2) {
                         if(error){ utils.display_error(error);
@@ -132,7 +132,7 @@ exports.post_update = function(data, callback){
  * @param {Pointer} callback
  * @api public
  */
-exports.get_latest = function(verbose, callback){	
+exports.get_latest = function(verbose, callback){
     oa.get(config.base_url+'/api/v1/messages/following.json?newer_than='+max_id,
         config.oauth_access_token,
         config.oauth_token_secret,
@@ -158,7 +158,7 @@ exports.get_latest = function(verbose, callback){
                 console.log('\n::: latest yams ::::\n'.green);
                 return view_yams(r.reverse(), callback);
             }
-    });	
+    });
 }
 /**
  * Search yams
@@ -167,7 +167,7 @@ exports.get_latest = function(verbose, callback){
  * @param {String} keyword
  * @api public
  */
-exports.search = function(verbose, keyword, num_per_page, callback){	
+exports.search = function(verbose, keyword, num_per_page, callback){
     oa.get(config.base_url+'/api/v1/search.json?search='+keyword+'&num_per_page=2',
         config.oauth_access_token,
         config.oauth_token_secret,
@@ -175,7 +175,7 @@ exports.search = function(verbose, keyword, num_per_page, callback){
             if(err) {
                 callback(err, false);
             } else {
-                var messages = [] 
+                var messages = []
                   , feed = JSON.parse(json)
                   , references = feed.messages.messages
                   , search_results = [];
@@ -183,11 +183,11 @@ exports.search = function(verbose, keyword, num_per_page, callback){
                     if(references[i].sender_type=='user') {
                       search_results.push(references[i]);
                     }
-                } 
+                }
                 console.log('\n::: search results ::::\n'.green);
                 for (var item in search_results.reverse()){
                   var result = search_results[item];
-                  (function(r){ 
+                  (function(r){
                     oa.get(config.base_url+'/api/v1/users/'+r.sender_id+'.json',
                        config.oauth_access_token,
                        config.oauth_token_secret,
@@ -199,10 +199,10 @@ exports.search = function(verbose, keyword, num_per_page, callback){
                               view_yam(usr.full_name,r.body.plain);
                            }
                     });
-                  })(result); 
+                  })(result);
                 }
             }
-    });	
+    });
 }
 /**
  * Get yam user
@@ -211,7 +211,7 @@ exports.search = function(verbose, keyword, num_per_page, callback){
  * @param {Integer} id
  * @api public
  */
-exports.get_user = function(verbose, id, callback){	
+exports.get_user = function(verbose, id, callback){
   oa.get(config.base_url+'/api/v1/users/'+id+'.json',
       config.oauth_access_token,
       config.oauth_token_secret,
@@ -222,7 +222,7 @@ exports.get_user = function(verbose, id, callback){
               var feed = JSON.parse(json);
               callback(null,true,feed);
           }
-  });	
+  });
 }
 /**
  * View / template
@@ -238,7 +238,7 @@ view_yams = function(list, callback){
           console.log('\n' + list[i].from.green + ": " + list[i].body.plain.grey);
       }
       console.log('\n')
-    } 
+    }
 }
 view_yam = function(from, body){
   console.log(from.green + ": " + body.grey + '\n');


### PR DESCRIPTION
Upon running `$ node cli.js` I was notified that util has replaced sys. This commit changes all references of `sys = require('sys')` to `util = require('util')` and any usage of `sys.` to `util.`

My editor defaults to stripping trailing whitespace as well, so you'll see a bunch of lines that don't look like they've been changed.
