### PR TITLE
Switch custom prompting module to promptly

### DIFF
--- a/lib/nyam.js
+++ b/lib/nyam.js
@@ -13,6 +13,7 @@ var fs = require('fs')
     , config = new ConfigObj()
     , utils = require('./utils')
     , nyam = require('./nyam')
+    , promptly = require('promptly')
     , colors = require('colors');
 
 /**
@@ -21,7 +22,6 @@ var fs = require('fs')
 var max_id = 0
     , get_latest
     , config_exists
-    , input
     , get_latest_view
     , debug = false
     , is_created = false
@@ -48,36 +48,6 @@ function Response(err,success,json){
 }
 
 /**
- * Input Utility
- *
- * @param {String} message
- * @param {Pointer} callback
- * @api private
- */
-input = function(message, callback){
-    var stdin = process.openStdin()
-    , stdio = process.binding("stdio")
-    , data = "";
-    stdio.setRawMode();
-    console.log(message);
-    stdin.on("data", function (c) {
-        c = c + "";
-        switch (c) {
-            case "\n": case "\r": case "\u0004":
-                stdio.setRawMode(false);
-                callback(data);
-                stdin.pause();
-                break
-            case "\u0003":
-                process.exit();
-                break
-            default:
-                data += c;
-                break
-        }
-    })
-}
-/**
  * Setup yammer
  *
  * @param {Pointer} callback
@@ -94,7 +64,7 @@ exports.setup = function(verbose, callback){
                 if (verbose) console.log('requestoken results :' + util.inspect(results));
                 console.log('\n:::::: we need to give this CLI tool access to yammer :::::::\n'.green.bold);
                 console.log('\nNavigate to: '.green + 'https://www.yammer.com/oauth/authorize?oauth_token='.grey.bold+ oauth_token.grey.bold+'\n');
-                return input("Enter authorization code: ".green, function(oauth_verifier){
+                return promptly.prompt("Enter authorization code: ".green, { 'trim': true }, function(oauth_verifier){
                     oa.getOAuthAccessToken(
                     oauth_token,
                     oauth_token_secret,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     }],
     "repository": {
       "type": "git",
-      "url": "http://github.com/csanz/nyam.git" 
+      "url": "http://github.com/csanz/nyam.git"
     },
     "engines":      {
       "node":       ">=0.4.0"
@@ -19,6 +19,7 @@
         "optimist": ">= 0.1.5"
       , "oauth": "0.9.0"
       , "colors": "*"
+      , "promptly": "~0.2.0"
     },
     "main" : "./lib/nyam",
     "bin":          {


### PR DESCRIPTION
Right now the tool doesn't function. Fails in node 0.8+ with No such module error (see csanz/node-nyam#4)

Quick patch to use a third party prompting module.
